### PR TITLE
New EllipseContext concept

### DIFF
--- a/ellipse-core/src/main/java/com/tomcz/ellipse/EffectsCollector.kt
+++ b/ellipse-core/src/main/java/com/tomcz/ellipse/EffectsCollector.kt
@@ -1,5 +1,0 @@
-package com.tomcz.ellipse
-
-interface EffectsCollector<T : Any> {
-    fun send(vararg effect: T)
-}

--- a/ellipse-core/src/main/java/com/tomcz/ellipse/EllipseContext.kt
+++ b/ellipse-core/src/main/java/com/tomcz/ellipse/EllipseContext.kt
@@ -1,0 +1,10 @@
+package com.tomcz.ellipse
+
+import kotlinx.coroutines.flow.Flow
+
+interface EllipseContext<ST : Any, EF : Any> {
+    var state: ST
+    fun setState(vararg partial: Partial<ST>)
+    fun setState(vararg flow: Flow<Partial<ST>>)
+    fun sendEffect(vararg effect: EF)
+}

--- a/ellipse-core/src/main/java/com/tomcz/ellipse/EllipseContext.kt
+++ b/ellipse-core/src/main/java/com/tomcz/ellipse/EllipseContext.kt
@@ -1,10 +1,8 @@
 package com.tomcz.ellipse
 
-import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.CoroutineScope
 
-interface EllipseContext<ST : Any, EF : Any> {
+interface EllipseContext<ST : Any, EF : Any> : CoroutineScope {
     var state: ST
-    fun setState(vararg partial: Partial<ST>)
-    fun setState(vararg flow: Flow<Partial<ST>>)
     fun sendEffect(vararg effect: EF)
 }

--- a/ellipse-core/src/main/java/com/tomcz/ellipse/Partial.kt
+++ b/ellipse-core/src/main/java/com/tomcz/ellipse/Partial.kt
@@ -1,0 +1,5 @@
+package com.tomcz.ellipse
+
+interface Partial<ST : Any> {
+    fun reduce(oldState: ST): ST
+}

--- a/ellipse-core/src/main/java/com/tomcz/ellipse/PartialState.kt
+++ b/ellipse-core/src/main/java/com/tomcz/ellipse/PartialState.kt
@@ -1,5 +1,0 @@
-package com.tomcz.ellipse
-
-interface PartialState<T : Any> {
-    fun reduce(oldState: T): T
-}

--- a/ellipse-core/src/main/java/com/tomcz/ellipse/common/CoroutineScopeExtension.kt
+++ b/ellipse-core/src/main/java/com/tomcz/ellipse/common/CoroutineScopeExtension.kt
@@ -1,13 +1,13 @@
 package com.tomcz.ellipse.common
 
-import com.tomcz.ellipse.PartialState
+import com.tomcz.ellipse.EllipseContext
+import com.tomcz.ellipse.Partial
 import com.tomcz.ellipse.Processor
 import com.tomcz.ellipse.internal.FlowProcessor
 import com.tomcz.ellipse.internal.util.consume
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.launch
 
 fun <EV : Any, EF : Any> CoroutineScope.processor(
@@ -15,14 +15,14 @@ fun <EV : Any, EF : Any> CoroutineScope.processor(
     onEvent: suspend EllipseContext<Unit, EF>.(EV) -> Unit = {},
 ): Processor<EV, Unit, EF> = processor(
     initialState = Unit,
-    { prepare(); emptyFlow() },
-    { onEvent(it); emptyFlow() }
+    { prepare() },
+    { onEvent(it) }
 )
 
-fun <EV : Any, ST : Any, PA : PartialState<ST>, EF : Any> CoroutineScope.processor(
+fun <EV : Any, ST : Any, PA : Partial<ST>, EF : Any> CoroutineScope.processor(
     initialState: ST,
-    prepare: suspend EllipseContext<ST, EF>.() -> Flow<PA> = { emptyFlow() },
-    onEvent: suspend EllipseContext<ST, EF>.(EV) -> Flow<PA> = { emptyFlow() },
+    prepare: suspend EllipseContext<ST, EF>.() -> Unit = {},
+    onEvent: suspend EllipseContext<ST, EF>.(EV) -> Unit = {},
 ): Processor<EV, ST, EF> = FlowProcessor(
     scope = this,
     initialState = initialState,

--- a/ellipse-core/src/main/java/com/tomcz/ellipse/common/EllipseContext.kt
+++ b/ellipse-core/src/main/java/com/tomcz/ellipse/common/EllipseContext.kt
@@ -1,9 +1,0 @@
-package com.tomcz.ellipse.common
-
-import com.tomcz.ellipse.EffectsCollector
-import kotlinx.coroutines.flow.StateFlow
-
-class EllipseContext<ST : Any, EF : Any>(
-    val state: StateFlow<ST>,
-    val effects: EffectsCollector<EF>
-)

--- a/ellipse-core/src/main/java/com/tomcz/ellipse/common/EllipseContextExtension.kt
+++ b/ellipse-core/src/main/java/com/tomcz/ellipse/common/EllipseContextExtension.kt
@@ -1,0 +1,18 @@
+package com.tomcz.ellipse.common
+
+import com.tomcz.ellipse.EllipseContext
+import com.tomcz.ellipse.Partial
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.merge
+import kotlinx.coroutines.flow.onEach
+
+fun <ST : Any, EF : Any> EllipseContext<ST, EF>.setState(vararg partial: Partial<ST>) {
+    partial.onEach { state = it.reduce(state) }
+}
+
+fun <ST : Any, EF : Any> EllipseContext<ST, EF>.setState(vararg flow: Flow<Partial<ST>>) {
+    merge(*flow)
+        .onEach { state = it.reduce(state) }
+        .launchIn(this)
+}

--- a/ellipse-core/src/main/java/com/tomcz/ellipse/common/FlowExtension.kt
+++ b/ellipse-core/src/main/java/com/tomcz/ellipse/common/FlowExtension.kt
@@ -1,14 +1,14 @@
 package com.tomcz.ellipse.common
 
-import com.tomcz.ellipse.PartialState
+import com.tomcz.ellipse.Partial
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 
 @JvmName("toNoActionAny")
-fun <T : Any> Flow<*>.toNoAction(): Flow<PartialState<T>> = map { NoAction() }
+fun <T : Any> Flow<*>.toNoAction(): Flow<Partial<T>> = map { NoAction() }
 
 @JvmName("toNoActionPartial")
-fun <T : Any> Flow<PartialState<T>>.toNoAction(): Flow<PartialState<T>> = this
+fun <T : Any> Flow<Partial<T>>.toNoAction(): Flow<Partial<T>> = this
 
-fun <T : Any> Any?.toNoAction(): Flow<PartialState<T>> = flowOf(NoAction())
+fun <T : Any> Any?.toNoAction(): Flow<Partial<T>> = flowOf(NoAction())

--- a/ellipse-core/src/main/java/com/tomcz/ellipse/common/PartialStateUtil.kt
+++ b/ellipse-core/src/main/java/com/tomcz/ellipse/common/PartialStateUtil.kt
@@ -1,8 +1,8 @@
 package com.tomcz.ellipse.common
 
-import com.tomcz.ellipse.PartialState
+import com.tomcz.ellipse.Partial
 
 @Suppress("FunctionName")
-fun <T : Any> NoAction(): PartialState<T> = object : PartialState<T> {
+fun <T : Any> NoAction(): Partial<T> = object : Partial<T> {
     override fun reduce(oldState: T): T = oldState
 }

--- a/ellipse-core/src/main/java/com/tomcz/ellipse/common/ViewModelExtension.kt
+++ b/ellipse-core/src/main/java/com/tomcz/ellipse/common/ViewModelExtension.kt
@@ -2,24 +2,22 @@ package com.tomcz.ellipse.common
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.tomcz.ellipse.PartialState
+import com.tomcz.ellipse.EllipseContext
 import com.tomcz.ellipse.Processor
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.emptyFlow
 
 fun <EV : Any, EF : Any> ViewModel.processor(
     prepare: suspend EllipseContext<Unit, EF>.() -> Unit = {},
     onEvent: suspend EllipseContext<Unit, EF>.(EV) -> Unit = {},
 ): Processor<EV, Unit, EF> = viewModelScope.processor(
     initialState = Unit,
-    prepare = { prepare(); emptyFlow() },
-    onEvent = { onEvent(it); emptyFlow() }
+    prepare = { prepare() },
+    onEvent = { onEvent(it) }
 )
 
-fun <EV : Any, ST : Any, PA : PartialState<ST>, EF : Any> ViewModel.processor(
+fun <EV : Any, ST : Any, EF : Any> ViewModel.processor(
     initialState: ST,
-    prepare: suspend EllipseContext<ST, EF>.() -> Flow<PA> = { emptyFlow() },
-    onEvent: suspend EllipseContext<ST, EF>.(EV) -> Flow<PA> = { emptyFlow() },
+    prepare: suspend EllipseContext<ST, EF>.() -> Unit = {},
+    onEvent: suspend EllipseContext<ST, EF>.(EV) -> Unit = {},
 ): Processor<EV, ST, EF> = viewModelScope.processor(
     initialState = initialState,
     prepare = prepare,

--- a/ellipse-core/src/main/java/com/tomcz/ellipse/internal/FlowProcessor.kt
+++ b/ellipse-core/src/main/java/com/tomcz/ellipse/internal/FlowProcessor.kt
@@ -56,7 +56,6 @@ internal class FlowProcessor<in EV : Any, ST : Any, EF : Any> constructor(
     }
 
     override fun sendEvent(vararg event: EV) {
-        println("yo ${event.joinToString(" ")}")
         scope.launch { event.forEach { onEvent(context, it) } }
     }
 

--- a/ellipse-core/src/main/java/com/tomcz/ellipse/internal/util/StateFlowExtension.kt
+++ b/ellipse-core/src/main/java/com/tomcz/ellipse/internal/util/StateFlowExtension.kt
@@ -1,8 +1,8 @@
 package com.tomcz.ellipse.internal.util
 
-import com.tomcz.ellipse.PartialState
+import com.tomcz.ellipse.Partial
 import kotlinx.coroutines.flow.MutableStateFlow
 
-fun <T : PartialState<K>, K : Any> MutableStateFlow<K>.reduceAndSet(intent: T) {
+fun <T : Partial<K>, K : Any> MutableStateFlow<K>.reduceAndSet(intent: T) {
     value = intent.reduce(value)
 }

--- a/ellipse-core/src/test/java/com/tomcz/ellipse/extensions/ProcessorExtensionsTest.kt
+++ b/ellipse-core/src/test/java/com/tomcz/ellipse/extensions/ProcessorExtensionsTest.kt
@@ -7,7 +7,6 @@ import com.tomcz.ellipse.util.BaseCoroutineTest
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.MainScope
-import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 
@@ -18,13 +17,13 @@ class ProcessorExtensionsTest : BaseCoroutineTest() {
 
     private val unitProcessor: Processor<Unit, Unit, Unit> = scope.processor(
         prepare = {},
-        onEvent = { effects.send(Unit) }
+        onEvent = { sendEffect(Unit) }
     )
 
     private val standardProcessor: Processor<Unit, String, Unit> = scope.processor(
         initialState = "",
-        prepare = { emptyFlow() },
-        onEvent = { effects.send(Unit); emptyFlow() }
+        prepare = {},
+        onEvent = { sendEffect(Unit) }
     )
 
     @Test

--- a/ellipse-core/src/test/java/com/tomcz/ellipse/internal/CounterState.kt
+++ b/ellipse-core/src/test/java/com/tomcz/ellipse/internal/CounterState.kt
@@ -1,6 +1,6 @@
 package com.tomcz.ellipse.internal
 
-import com.tomcz.ellipse.PartialState
+import com.tomcz.ellipse.Partial
 
 object CounterEvent
 
@@ -8,7 +8,7 @@ object CounterEffect
 
 data class CounterState(val counter: Int = 0)
 
-object IncreasePartialState : PartialState<CounterState> {
+object IncreasePartial : Partial<CounterState> {
     override fun reduce(oldState: CounterState): CounterState =
         oldState.copy(counter = oldState.counter + 1)
 }

--- a/ellipse-core/src/test/java/com/tomcz/ellipse/internal/FlowEffectProcessorTest.kt
+++ b/ellipse-core/src/test/java/com/tomcz/ellipse/internal/FlowEffectProcessorTest.kt
@@ -22,7 +22,7 @@ internal class FlowEffectProcessorTest : BaseCoroutineTest() {
     fun `test effect`() = runTest {
         val processorScope = TestScope(testScheduler)
         val processor: CounterEffectProcessor =
-            processorScope.processor { effects.send(CounterEffect) }
+            processorScope.processor { sendEffect(CounterEffect) }
         val effects = mutableListOf<CounterEffect>()
         val effectJob = launch { processor.effect.collect { effects.add(it) } }
         processor.sendEvent(CounterEvent)
@@ -36,7 +36,7 @@ internal class FlowEffectProcessorTest : BaseCoroutineTest() {
     fun `test resubscribing effects`() = runTest {
         val processorScope = TestScope(testScheduler)
         val processor: CounterEffectProcessor =
-            processorScope.processor { effects.send(CounterEffect) }
+            processorScope.processor { sendEffect(CounterEffect) }
         val effects = mutableListOf<CounterEffect>()
         val effectJob = launch { processor.effect.collect { effects.add(it) } }
         processor.sendEvent(CounterEvent)
@@ -56,7 +56,7 @@ internal class FlowEffectProcessorTest : BaseCoroutineTest() {
     fun `test having multiple subscribers`() = runTest {
         val processorScope = TestScope(testScheduler)
         val processor: CounterEffectProcessor =
-            processorScope.processor { effects.send(CounterEffect) }
+            processorScope.processor { sendEffect(CounterEffect) }
         val effects = mutableListOf<CounterEffect>()
         val effectJob = launch { processor.effect.collect { effects.add(it) } }
         val effect2Job = launch { processor.effect.collect { effects.add(it) } }
@@ -78,7 +78,7 @@ internal class FlowEffectProcessorTest : BaseCoroutineTest() {
     fun `test caching effects when there are no subscribers`() = runTest {
         val processorScope = TestScope(testScheduler)
         val processor: CounterEffectProcessor = processorScope.processor {
-            effects.send(CounterEffect)
+            sendEffect(CounterEffect)
         }
         val effects = mutableListOf<CounterEffect>()
         val effectJob = launch { processor.effect.collect { effects.add(it) } }

--- a/ellipse-core/src/test/java/com/tomcz/ellipse/internal/FlowProcessorTest.kt
+++ b/ellipse-core/src/test/java/com/tomcz/ellipse/internal/FlowProcessorTest.kt
@@ -187,7 +187,6 @@ internal class FlowProcessorTest : BaseCoroutineTest() {
                 CounterState(),
                 prepare = { setState(IncreasePartial) }
             ) {
-                println("state $state")
                 sendEffect(CounterEffect)
                 setState(IncreasePartial)
             }

--- a/ellipse-core/src/test/java/com/tomcz/ellipse/internal/FlowProcessorTest.kt
+++ b/ellipse-core/src/test/java/com/tomcz/ellipse/internal/FlowProcessorTest.kt
@@ -2,11 +2,11 @@ package com.tomcz.ellipse.internal
 
 import com.tomcz.ellipse.Processor
 import com.tomcz.ellipse.common.processor
+import com.tomcz.ellipse.common.setState
 import com.tomcz.ellipse.util.BaseCoroutineTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.cancelAndJoin
-import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.TestScope
@@ -31,7 +31,7 @@ internal class FlowProcessorTest : BaseCoroutineTest() {
     fun `test default state and prepare`() = runTest {
         val scope = TestScope(testScheduler)
         val processor: Processor<CounterEvent, CounterState, CounterEffect> =
-            scope.processor(CounterState(), prepare = { flow { emit(IncreasePartial) } })
+            scope.processor(CounterState(), prepare = { setState(IncreasePartial) })
         runCurrent()
         assertEquals(CounterState(1), processor.state.value)
         scope.cancel()
@@ -41,7 +41,7 @@ internal class FlowProcessorTest : BaseCoroutineTest() {
     fun `test state change after event`() = runTest {
         val scope = TestScope(testScheduler)
         val processor: Processor<CounterEvent, CounterState, CounterEffect> =
-            scope.processor(CounterState()) { flow { emit(IncreasePartial) } }
+            scope.processor(CounterState()) { setState(IncreasePartial) }
         assertEquals(CounterState(0), processor.state.value)
         processor.sendEvent(CounterEvent)
         runCurrent()
@@ -54,8 +54,23 @@ internal class FlowProcessorTest : BaseCoroutineTest() {
         val scope = TestScope(testScheduler)
         val processor: Processor<CounterEvent, CounterState, CounterEffect> =
             scope.processor(
-                CounterState(), prepare = { flow { emit(IncreasePartial) } }
-            ) { flow { emit(IncreasePartial) } }
+                CounterState(), prepare = { setState(IncreasePartial) }
+            ) { setState(IncreasePartial) }
+        runCurrent()
+        assertEquals(CounterState(1), processor.state.value)
+        processor.sendEvent(CounterEvent)
+        runCurrent()
+        assertEquals(CounterState(2), processor.state.value)
+        scope.cancel()
+    }
+
+    @Test
+    fun `test another prepare and state change after event`() = runTest {
+        val scope = TestScope(testScheduler)
+        val processor: Processor<CounterEvent, CounterState, CounterEffect> =
+            scope.processor(
+                CounterState(), prepare = { setState(flow { emit(IncreasePartial) }) }
+            ) { setState(flow { emit(IncreasePartial) }) }
         runCurrent()
         assertEquals(CounterState(1), processor.state.value)
         processor.sendEvent(CounterEvent)
@@ -70,10 +85,9 @@ internal class FlowProcessorTest : BaseCoroutineTest() {
         val processor: Processor<CounterEvent, CounterState, CounterEffect> =
             scope.processor(
                 CounterState(),
-                prepare = { flow { emit(IncreasePartial) } }
+                prepare = { setState(IncreasePartial) }
             ) {
-                effects.send(CounterEffect)
-                emptyFlow()
+                sendEffect(CounterEffect)
             }
         val effects = mutableListOf<CounterEffect>()
         val effectJob = launch { processor.effect.collect { effects.add(it) } }
@@ -90,9 +104,9 @@ internal class FlowProcessorTest : BaseCoroutineTest() {
         val processor: Processor<CounterEvent, CounterState, CounterEffect> =
             processorScope.processor(
                 CounterState(),
-                prepare = { flow { emit(IncreasePartial) } }
+                prepare = { setState(IncreasePartial) }
             ) {
-                flow { emit(IncreasePartial) }
+                setState(IncreasePartial)
             }
         val stateEvents = mutableListOf<CounterState>()
         val job = launch { processor.state.collect { stateEvents.add(it) } }
@@ -117,10 +131,10 @@ internal class FlowProcessorTest : BaseCoroutineTest() {
         val processor: Processor<CounterEvent, CounterState, CounterEffect> =
             processorScope.processor(
                 CounterState(),
-                prepare = { flow { emit(IncreasePartial) } }
+                prepare = { setState(IncreasePartial) }
             ) {
-                effects.send(CounterEffect)
-                flow { emit(IncreasePartial) }
+                sendEffect(CounterEffect)
+                setState(IncreasePartial)
             }
         val effects = mutableListOf<CounterEffect>()
         val effectJob = launch { processor.effect.collect { effects.add(it) } }
@@ -146,7 +160,7 @@ internal class FlowProcessorTest : BaseCoroutineTest() {
     fun `test having multiple subscribers`() = runTest {
         val processorScope = TestScope(testScheduler)
         val processor: Processor<CounterEvent, CounterState, CounterEffect> =
-            processorScope.processor(CounterState()) { effects.send(CounterEffect); emptyFlow() }
+            processorScope.processor(CounterState()) { sendEffect(CounterEffect) }
         val effects = mutableListOf<CounterEffect>()
         val effectJob = launch { processor.effect.collect { effects.add(it) } }
         val effect2Job = launch { processor.effect.collect { effects.add(it) } }
@@ -171,10 +185,11 @@ internal class FlowProcessorTest : BaseCoroutineTest() {
         val processor: Processor<CounterEvent, CounterState, CounterEffect> =
             processorScope.processor(
                 CounterState(),
-                prepare = { flow { emit(IncreasePartial) } }
+                prepare = { setState(IncreasePartial) }
             ) {
-                effects.send(CounterEffect)
-                flow { emit(IncreasePartial) }
+                println("state $state")
+                sendEffect(CounterEffect)
+                setState(IncreasePartial)
             }
         val effects = mutableListOf<CounterEffect>()
         val effectJob = launch { processor.effect.collect { effects.add(it) } }
@@ -186,8 +201,7 @@ internal class FlowProcessorTest : BaseCoroutineTest() {
         assertEquals(listOf(CounterEffect), effects)
         effectJob.cancelAndJoin()
 
-        processor.sendEvent(CounterEvent)
-        processor.sendEvent(CounterEvent)
+        processor.sendEvent(CounterEvent, CounterEvent)
 
         // Test resubscribing
         val cachedEffects = mutableListOf<CounterEffect>()

--- a/ellipse-core/src/test/java/com/tomcz/ellipse/internal/FlowProcessorTest.kt
+++ b/ellipse-core/src/test/java/com/tomcz/ellipse/internal/FlowProcessorTest.kt
@@ -31,7 +31,7 @@ internal class FlowProcessorTest : BaseCoroutineTest() {
     fun `test default state and prepare`() = runTest {
         val scope = TestScope(testScheduler)
         val processor: Processor<CounterEvent, CounterState, CounterEffect> =
-            scope.processor(CounterState(), prepare = { flow { emit(IncreasePartialState) } })
+            scope.processor(CounterState(), prepare = { flow { emit(IncreasePartial) } })
         runCurrent()
         assertEquals(CounterState(1), processor.state.value)
         scope.cancel()
@@ -41,7 +41,7 @@ internal class FlowProcessorTest : BaseCoroutineTest() {
     fun `test state change after event`() = runTest {
         val scope = TestScope(testScheduler)
         val processor: Processor<CounterEvent, CounterState, CounterEffect> =
-            scope.processor(CounterState()) { flow { emit(IncreasePartialState) } }
+            scope.processor(CounterState()) { flow { emit(IncreasePartial) } }
         assertEquals(CounterState(0), processor.state.value)
         processor.sendEvent(CounterEvent)
         runCurrent()
@@ -54,8 +54,8 @@ internal class FlowProcessorTest : BaseCoroutineTest() {
         val scope = TestScope(testScheduler)
         val processor: Processor<CounterEvent, CounterState, CounterEffect> =
             scope.processor(
-                CounterState(), prepare = { flow { emit(IncreasePartialState) } }
-            ) { flow { emit(IncreasePartialState) } }
+                CounterState(), prepare = { flow { emit(IncreasePartial) } }
+            ) { flow { emit(IncreasePartial) } }
         runCurrent()
         assertEquals(CounterState(1), processor.state.value)
         processor.sendEvent(CounterEvent)
@@ -70,7 +70,7 @@ internal class FlowProcessorTest : BaseCoroutineTest() {
         val processor: Processor<CounterEvent, CounterState, CounterEffect> =
             scope.processor(
                 CounterState(),
-                prepare = { flow { emit(IncreasePartialState) } }
+                prepare = { flow { emit(IncreasePartial) } }
             ) {
                 effects.send(CounterEffect)
                 emptyFlow()
@@ -90,9 +90,9 @@ internal class FlowProcessorTest : BaseCoroutineTest() {
         val processor: Processor<CounterEvent, CounterState, CounterEffect> =
             processorScope.processor(
                 CounterState(),
-                prepare = { flow { emit(IncreasePartialState) } }
+                prepare = { flow { emit(IncreasePartial) } }
             ) {
-                flow { emit(IncreasePartialState) }
+                flow { emit(IncreasePartial) }
             }
         val stateEvents = mutableListOf<CounterState>()
         val job = launch { processor.state.collect { stateEvents.add(it) } }
@@ -117,10 +117,10 @@ internal class FlowProcessorTest : BaseCoroutineTest() {
         val processor: Processor<CounterEvent, CounterState, CounterEffect> =
             processorScope.processor(
                 CounterState(),
-                prepare = { flow { emit(IncreasePartialState) } }
+                prepare = { flow { emit(IncreasePartial) } }
             ) {
                 effects.send(CounterEffect)
-                flow { emit(IncreasePartialState) }
+                flow { emit(IncreasePartial) }
             }
         val effects = mutableListOf<CounterEffect>()
         val effectJob = launch { processor.effect.collect { effects.add(it) } }
@@ -171,10 +171,10 @@ internal class FlowProcessorTest : BaseCoroutineTest() {
         val processor: Processor<CounterEvent, CounterState, CounterEffect> =
             processorScope.processor(
                 CounterState(),
-                prepare = { flow { emit(IncreasePartialState) } }
+                prepare = { flow { emit(IncreasePartial) } }
             ) {
                 effects.send(CounterEffect)
-                flow { emit(IncreasePartialState) }
+                flow { emit(IncreasePartial) }
             }
         val effects = mutableListOf<CounterEffect>()
         val effectJob = launch { processor.effect.collect { effects.add(it) } }

--- a/sample/src/main/java/com/tomcz/sample/common/Util.kt
+++ b/sample/src/main/java/com/tomcz/sample/common/Util.kt
@@ -5,7 +5,11 @@ import kotlinx.coroutines.flow.FlowCollector
 import kotlinx.coroutines.flow.callbackFlow
 import kotlin.coroutines.cancellation.CancellationException
 
-fun <T> onCancel(action: () -> Unit) = callbackFlow<T> {
+// fun <T> onCancel(action: () -> Unit) = callbackFlow<T> {
+//     awaitClose { action() }
+// }
+
+fun onCancel(action: () -> Unit) = callbackFlow<Unit> {
     awaitClose { action() }
 }
 

--- a/sample/src/main/java/com/tomcz/sample/common/Util.kt
+++ b/sample/src/main/java/com/tomcz/sample/common/Util.kt
@@ -1,17 +1,15 @@
 package com.tomcz.sample.common
 
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.FlowCollector
 import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.flow.launchIn
 import kotlin.coroutines.cancellation.CancellationException
 
-// fun <T> onCancel(action: () -> Unit) = callbackFlow<T> {
-//     awaitClose { action() }
-// }
-
-fun onCancel(action: () -> Unit) = callbackFlow<Unit> {
+fun CoroutineScope.onCancel(action: () -> Unit) = callbackFlow<Unit> {
     awaitClose { action() }
-}
+}.launchIn(this)
 
 suspend fun <T> FlowCollector<T>.emitAbort(value: T): Nothing {
     emit(value)

--- a/sample/src/main/java/com/tomcz/sample/feature/foo/FooViewModel.kt
+++ b/sample/src/main/java/com/tomcz/sample/feature/foo/FooViewModel.kt
@@ -1,12 +1,15 @@
 package com.tomcz.sample.feature.foo
 
 import androidx.lifecycle.ViewModel
+import com.tomcz.ellipse.EllipseContext
 import com.tomcz.ellipse.Processor
 import com.tomcz.ellipse.common.NoAction
 import com.tomcz.ellipse.common.processor
-import com.tomcz.ellipse.common.toNoAction
+import com.tomcz.ellipse.common.setState
 import com.tomcz.sample.common.AndroidDispatcherProvider
 import com.tomcz.sample.common.DispatcherProvider
+import com.tomcz.sample.common.emitAbort
+import com.tomcz.sample.common.onCancel
 import com.tomcz.sample.feature.foo.state.FooEffect
 import com.tomcz.sample.feature.foo.state.FooEffect.BarEffect
 import com.tomcz.sample.feature.foo.state.FooEvent
@@ -17,16 +20,15 @@ import com.tomcz.sample.feature.foo.state.FooEvent.ThirdButtonClick
 import com.tomcz.sample.feature.foo.state.FooPartial.Decrease
 import com.tomcz.sample.feature.foo.state.FooPartial.Increase
 import com.tomcz.sample.feature.foo.state.FooState
-import com.tomcz.sample.common.emitAbort
-import com.tomcz.sample.common.onCancel
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.flatMapConcat
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
-import kotlinx.coroutines.flow.merge
+import kotlinx.coroutines.flow.launchIn
 
 typealias FooProcessor = Processor<FooEvent, FooState, FooEffect>
+typealias FooContext = EllipseContext<FooState, FooEffect>
 
 @FlowPreview
 class FooViewModel(
@@ -38,40 +40,49 @@ class FooViewModel(
     val processor: FooProcessor = processor(
         initialState = FooState(),
         prepare = {
-            effects.send(BarEffect)
-            val firstFlow = flow {
-                emit(Increase) // 1
-                emit(Decrease) // 0
-                delay(100)
-                emit(Increase) // 1
-            }
-            effects.send(BarEffect)
+            sendEffect(BarEffect)
+            firstPrepareFlow()
+            sendEffect(BarEffect)
             delay(100)
-            effects.send(BarEffect)
-            val secondFlow = flow {
-                delay(100)
-                emit(Increase) // 2
-                emit(Decrease) // 1
-            }
-            merge(
-                onCancel { bar.close() },
-                firstFlow,
-                secondFlow
-            )
+            sendEffect(BarEffect)
+            secondPrepareFlow()
+            onCancel { bar.close() }
+                .launchIn(this)
         },
         onEvent = { event ->
             when (event) {
-                FirstButtonClick -> flowOf(Increase)
-                SecondButtonClick -> flowOf(NoAction())
-                ThirdButtonClick -> effects.send(BarEffect).toNoAction()
-                FourthButtonClick -> bar.infiniteStream().flatMapConcat { condition ->
-                    if (condition) {
-                        flow { emitAbort(Decrease) }
-                    } else {
-                        flowOf(NoAction())
-                    }
-                }
+                FirstButtonClick -> setState(Increase)
+                SecondButtonClick -> setState(NoAction())
+                ThirdButtonClick -> sendEffect(BarEffect)
+                FourthButtonClick -> fourthClick()
             }
         }
     )
+
+    private fun FooContext.firstPrepareFlow() {
+        setState(flow {
+            emit(Increase) // 1
+            emit(Decrease) // 0
+            delay(100)
+            emit(Increase) // 1
+        })
+    }
+
+    private fun FooContext.secondPrepareFlow() {
+        setState(flow {
+            delay(100)
+            emit(Increase) // 2
+            emit(Decrease) // 1
+        })
+    }
+
+    private fun FooContext.fourthClick() {
+        setState(bar.infiniteStream().flatMapConcat { condition ->
+            if (condition) {
+                flow { emitAbort(Decrease) }
+            } else {
+                flowOf(NoAction())
+            }
+        })
+    }
 }

--- a/sample/src/main/java/com/tomcz/sample/feature/foo/FooViewModel.kt
+++ b/sample/src/main/java/com/tomcz/sample/feature/foo/FooViewModel.kt
@@ -25,7 +25,6 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.flatMapConcat
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
-import kotlinx.coroutines.flow.launchIn
 
 typealias FooProcessor = Processor<FooEvent, FooState, FooEffect>
 typealias FooContext = EllipseContext<FooState, FooEffect>
@@ -47,7 +46,6 @@ class FooViewModel(
             sendEffect(BarEffect)
             secondPrepareFlow()
             onCancel { bar.close() }
-                .launchIn(this)
         },
         onEvent = { event ->
             when (event) {

--- a/sample/src/main/java/com/tomcz/sample/feature/foo/state/FooPartial.kt
+++ b/sample/src/main/java/com/tomcz/sample/feature/foo/state/FooPartial.kt
@@ -1,8 +1,8 @@
 package com.tomcz.sample.feature.foo.state
 
-import com.tomcz.ellipse.PartialState
+import com.tomcz.ellipse.Partial
 
-sealed interface FooPartial : PartialState<FooState> {
+sealed interface FooPartial : Partial<FooState> {
 
     object Increase : FooPartial {
         override fun reduce(oldState: FooState): FooState =

--- a/sample/src/main/java/com/tomcz/sample/feature/login/LoginViewModel.kt
+++ b/sample/src/main/java/com/tomcz/sample/feature/login/LoginViewModel.kt
@@ -3,14 +3,12 @@ package com.tomcz.sample.feature.login
 import androidx.lifecycle.ViewModel
 import com.tomcz.ellipse.Processor
 import com.tomcz.ellipse.common.processor
-import com.tomcz.ellipse.common.toNoAction
 import com.tomcz.sample.feature.login.state.LoginEffect
 import com.tomcz.sample.feature.login.state.LoginEvent
-import com.tomcz.sample.feature.login.state.LoginPartialState
+import com.tomcz.sample.feature.login.state.LoginPartial
 import com.tomcz.sample.feature.login.state.LoginState
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.flow.flow
 import javax.inject.Inject
 
 typealias LoginProcessor = Processor<LoginEvent, LoginState, LoginEffect>
@@ -20,17 +18,17 @@ class LoginViewModel @Inject constructor() : ViewModel() {
 
     val processor: LoginProcessor = processor(initialState = LoginState()) { event ->
         when (event) {
-            is LoginEvent.LoginClick -> flow {
-                emit(LoginPartialState.ShowLoading)
+            is LoginEvent.LoginClick -> {
+                setState(LoginPartial.ShowLoading)
                 val isSuccess = loginUser(event.email, event.pass)
-                emit(LoginPartialState.HideLoading)
+                setState(LoginPartial.HideLoading)
                 if (isSuccess) {
-                    effects.send(LoginEffect.GoToHome)
+                    sendEffect(LoginEffect.GoToHome)
                 } else {
-                    effects.send(LoginEffect.ShowError)
+                    sendEffect(LoginEffect.ShowError)
                 }
             }
-            LoginEvent.GoToRegister -> effects.send(LoginEffect.GoToRegister).toNoAction()
+            LoginEvent.GoToRegister -> sendEffect(LoginEffect.GoToRegister)
         }
     }
 

--- a/sample/src/main/java/com/tomcz/sample/feature/login/LoginViewModel.kt
+++ b/sample/src/main/java/com/tomcz/sample/feature/login/LoginViewModel.kt
@@ -3,6 +3,7 @@ package com.tomcz.sample.feature.login
 import androidx.lifecycle.ViewModel
 import com.tomcz.ellipse.Processor
 import com.tomcz.ellipse.common.processor
+import com.tomcz.ellipse.common.setState
 import com.tomcz.sample.feature.login.state.LoginEffect
 import com.tomcz.sample.feature.login.state.LoginEvent
 import com.tomcz.sample.feature.login.state.LoginPartial
@@ -34,6 +35,6 @@ class LoginViewModel @Inject constructor() : ViewModel() {
 
     private suspend fun loginUser(email: String, pass: String): Boolean {
         delay(2000)
-        return true
+        return email == "a" && pass == "b"
     }
 }

--- a/sample/src/main/java/com/tomcz/sample/feature/login/state/LoginPartial.kt
+++ b/sample/src/main/java/com/tomcz/sample/feature/login/state/LoginPartial.kt
@@ -1,13 +1,13 @@
 package com.tomcz.sample.feature.login.state
 
-import com.tomcz.ellipse.PartialState
+import com.tomcz.ellipse.Partial
 
-sealed interface LoginPartialState : PartialState<LoginState> {
-    object ShowLoading : LoginPartialState {
+sealed interface LoginPartial : Partial<LoginState> {
+    object ShowLoading : LoginPartial {
         override fun reduce(oldState: LoginState): LoginState = oldState.copy(isLoading = true)
     }
 
-    object HideLoading : LoginPartialState {
+    object HideLoading : LoginPartial {
         override fun reduce(oldState: LoginState): LoginState = oldState.copy(isLoading = true)
     }
 }

--- a/sample/src/main/java/com/tomcz/sample/feature/register/RegisterViewModel.kt
+++ b/sample/src/main/java/com/tomcz/sample/feature/register/RegisterViewModel.kt
@@ -3,6 +3,7 @@ package com.tomcz.sample.feature.register
 import androidx.lifecycle.ViewModel
 import com.tomcz.ellipse.Processor
 import com.tomcz.ellipse.common.processor
+import com.tomcz.ellipse.common.setState
 import com.tomcz.sample.feature.register.state.RegisterEffect
 import com.tomcz.sample.feature.register.state.RegisterEvent
 import com.tomcz.sample.feature.register.state.RegisterPartial.EmailChanged
@@ -26,6 +27,7 @@ class RegisterViewModel @Inject constructor() : ViewModel() {
         initialState = RegisterState(),
         prepare = { },
         onEvent = { event ->
+            state = state.copy(email = "")
             when (event) {
                 is RegisterEvent.EmailChanged -> setState(EmailChanged(event.email))
                 is RegisterEvent.PasswordChanged -> setState(flowOf(PasswordChanged(event.password)))

--- a/sample/src/main/java/com/tomcz/sample/feature/register/state/RegisterPartial.kt
+++ b/sample/src/main/java/com/tomcz/sample/feature/register/state/RegisterPartial.kt
@@ -1,22 +1,22 @@
 package com.tomcz.sample.feature.register.state
 
-import com.tomcz.ellipse.PartialState
+import com.tomcz.ellipse.Partial
 
-sealed interface RegisterPartialState : PartialState<RegisterState> {
+sealed interface RegisterPartial : Partial<RegisterState> {
 
-    data class EmailChanged(val email: String) : RegisterPartialState {
+    data class EmailChanged(val email: String) : RegisterPartial {
         override fun reduce(oldState: RegisterState): RegisterState {
             return oldState.copy(email = email)
         }
     }
 
-    data class PasswordChanged(val password: String) : RegisterPartialState {
+    data class PasswordChanged(val password: String) : RegisterPartial {
         override fun reduce(oldState: RegisterState): RegisterState {
             return oldState.copy(password = password)
         }
     }
 
-    data class RepeatPasswordChanged(val repeatPassword: String) : RegisterPartialState {
+    data class RepeatPasswordChanged(val repeatPassword: String) : RegisterPartial {
         override fun reduce(oldState: RegisterState): RegisterState {
             return oldState.copy(repeatPassword = repeatPassword)
         }


### PR DESCRIPTION
## ⚠️ Breaking changes! 
#### Migration guide

- Rename `PartialState` to `Partial`, e.g. `PartialState<MyState>` > `Partial<MyState>`
- `onEvent` and `prepare` no longer takes `Flow<PartialState<T>>` as a return type, instead it doesn't expect any value (`Unit`). This migration can't be done by simply renaming something on the project level. Some probably logic has to be rewritten. Instead of returning the flow, you can call function `setState(Partial)` or `setState(Flow<Partial>)`, so if previously you had:
```kotlin
onEvent { event ->
  when(event) {
    is MyEvent -> flow { emit(Partial) }
    is MyOtherEvent -> flowReturnedFromUseCase().map { Partial(it) }
    is MyOtherOtherEvent -> effects.send(MyEffect).toNoAction()
  }
}
```
then migrated code could look like that:
```kotlin
onEvent { event ->
  when(event) {
    is MyEvent -> setState(flow { emit(Partial) })
    is MyOtherEvent -> setState(flowReturnedFromUseCase().map { Partial(it) })
    is MyOtherOtherEvent -> sendEffect(MyEffect)
  }
}
```