### PR TITLE
Add new cache for effects; Support for multiple subscribers

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -17,7 +17,6 @@
             <option value="$PROJECT_DIR$/sample" />
           </set>
         </option>
-        <option name="resolveModulePerSourceSet" value="false" />
       </GradleProjectSettings>
     </option>
   </component>

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -2,6 +2,7 @@ import org.gradle.api.artifacts.dsl.DependencyHandler
 
 fun DependencyHandler.kotlin() {
     implementation(Libs.Jetbrains.kotlinStdlib)
+    implementation(Libs.Jetbrains.kotlinReflect)
 }
 
 fun DependencyHandler.baseAndroid() {

--- a/buildSrc/src/main/java/Libs.kt
+++ b/buildSrc/src/main/java/Libs.kt
@@ -60,6 +60,7 @@ object Libs {
 
     object Jetbrains {
         const val kotlinStdlib = "org.jetbrains.kotlin:kotlin-stdlib:${Versions.kotlin}"
+        const val kotlinReflect = "org.jetbrains.kotlin:kotlin-reflect:${Versions.kotlin}"
 
         object Coroutines {
             const val core = "org.jetbrains.kotlinx:kotlinx-coroutines-core:${Versions.coroutines}"

--- a/ellipse-core/build.gradle.kts
+++ b/ellipse-core/build.gradle.kts
@@ -12,6 +12,7 @@ android {
 
 dependencies {
     implementation(Libs.Jetbrains.kotlinStdlib)
+    implementation(Libs.Jetbrains.kotlinReflect)
     implementation(Libs.AndroidX.appCompat)
     implementation(Libs.AndroidX.vmKtx)
     implementation(Libs.AndroidX.lifecycleRuntimeKtx)

--- a/ellipse-core/src/main/java/com/tomcz/ellipse/Processor.kt
+++ b/ellipse-core/src/main/java/com/tomcz/ellipse/Processor.kt
@@ -3,10 +3,12 @@ package com.tomcz.ellipse
 import androidx.compose.runtime.Stable
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.StateFlow
+import kotlin.reflect.KClass
 
 @Stable
-interface Processor<in EV : Any, out ST : Any, out EF : Any> {
+interface Processor<in EV : Any, out ST : Any, EF : Any> {
     val state: StateFlow<ST>
     val effect: Flow<EF>
+    fun <T : EF> effect(filterClass: KClass<T>): Flow<T>
     fun sendEvent(vararg event: EV)
 }

--- a/ellipse-core/src/main/java/com/tomcz/ellipse/common/ComposeExtension.kt
+++ b/ellipse-core/src/main/java/com/tomcz/ellipse/common/ComposeExtension.kt
@@ -16,6 +16,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.map
+import kotlin.reflect.KClass
 
 @Composable
 fun <EV : Any, ST : Any, T> Processor<EV, ST, *>.collectAsState(
@@ -32,13 +33,15 @@ fun <EV : Any, ST : Any, T> Processor<EV, ST, *>.collectAsState(
 
 @SuppressLint("ComposableNaming")
 @Composable
-fun <EV : Any, ST : Any, EF : Any> Processor<EV, ST, EF>.collectEffect(
+inline fun <EV : Any, ST : Any, reified EF : Any, reified T : EF> Processor<EV, ST, EF>.collectEffect(
+    effectClass: KClass<T> = T::class,
     lifecycleState: Lifecycle.State = Lifecycle.State.STARTED,
-    collect: suspend (EF) -> Unit
+    noinline collect: suspend (T) -> Unit
 ) {
     val lifecycleOwner = LocalLifecycleOwner.current
-    val flow = remember(effect, lifecycleOwner) {
-        effect.flowWithLifecycle(lifecycleOwner.lifecycle, lifecycleState)
+    val filteredFlow = remember(this) { effect(effectClass) }
+    val flow = remember(filteredFlow, lifecycleOwner) {
+        filteredFlow.flowWithLifecycle(lifecycleOwner.lifecycle, lifecycleState)
     }
     LaunchedEffect(flow) { flow.collect { collect(it) } }
 }
@@ -49,6 +52,7 @@ fun <EV : Any, ST : Any, EF : Any> previewProcessor(
 
     override val state: StateFlow<ST> = MutableStateFlow(state)
     override val effect: Flow<EF> = emptyFlow()
+    override fun <T : EF> effect(filterClass: KClass<T>): Flow<T> = emptyFlow()
 
     override fun sendEvent(vararg event: EV) {
         /* no-op */

--- a/ellipse-core/src/main/java/com/tomcz/ellipse/common/ComposeExtension.kt
+++ b/ellipse-core/src/main/java/com/tomcz/ellipse/common/ComposeExtension.kt
@@ -34,12 +34,12 @@ fun <EV : Any, ST : Any, T> Processor<EV, ST, *>.collectAsState(
 @SuppressLint("ComposableNaming")
 @Composable
 inline fun <EV : Any, ST : Any, reified EF : Any, reified T : EF> Processor<EV, ST, EF>.collectEffect(
-    effectClass: KClass<T> = T::class,
+    effectClass: KClass<T>,
     lifecycleState: Lifecycle.State = Lifecycle.State.STARTED,
     noinline collect: suspend (T) -> Unit
 ) {
     val lifecycleOwner = LocalLifecycleOwner.current
-    val filteredFlow = remember(this) { effect(effectClass) }
+    val filteredFlow = remember(this, effectClass) { effect(effectClass) }
     val flow = remember(filteredFlow, lifecycleOwner) {
         filteredFlow.flowWithLifecycle(lifecycleOwner.lifecycle, lifecycleState)
     }

--- a/ellipse-core/src/main/java/com/tomcz/ellipse/common/CoroutineScopeExtension.kt
+++ b/ellipse-core/src/main/java/com/tomcz/ellipse/common/CoroutineScopeExtension.kt
@@ -10,21 +10,22 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.launch
 
-fun <EV : Any, EF : Any> CoroutineScope.processor(
-    prepare: suspend EllipseContext<Unit, EF>.() -> Unit = {},
-    onEvent: suspend EllipseContext<Unit, EF>.(EV) -> Unit = {},
+inline fun <EV : Any, reified EF : Any> CoroutineScope.processor(
+    noinline prepare: suspend EllipseContext<Unit, EF>.() -> Unit = {},
+    noinline onEvent: suspend EllipseContext<Unit, EF>.(EV) -> Unit = {},
 ): Processor<EV, Unit, EF> = processor(
     initialState = Unit,
     { prepare(); emptyFlow() },
     { onEvent(it); emptyFlow() }
 )
 
-fun <EV : Any, ST : Any, PA : PartialState<ST>, EF : Any> CoroutineScope.processor(
+inline fun <EV : Any, ST : Any, PA : PartialState<ST>, reified EF : Any> CoroutineScope.processor(
     initialState: ST,
-    prepare: suspend EllipseContext<ST, EF>.() -> Flow<PA> = { emptyFlow() },
-    onEvent: suspend EllipseContext<ST, EF>.(EV) -> Flow<PA> = { emptyFlow() },
+    noinline prepare: suspend EllipseContext<ST, EF>.() -> Flow<PA> = { emptyFlow() },
+    noinline onEvent: suspend EllipseContext<ST, EF>.(EV) -> Flow<PA> = { emptyFlow() },
 ): Processor<EV, ST, EF> = FlowProcessor(
     scope = this,
+    effectClass = EF::class,
     initialState = initialState,
     prepare = prepare,
     onEvent = onEvent

--- a/ellipse-core/src/main/java/com/tomcz/ellipse/common/EllipseContextExtension.kt
+++ b/ellipse-core/src/main/java/com/tomcz/ellipse/common/EllipseContextExtension.kt
@@ -1,0 +1,5 @@
+package com.tomcz.ellipse.common
+
+fun <ST : Any, EF : Any> EllipseContext<ST, EF>.sendEffect(vararg effect: EF) {
+    effects.send(*effect)
+}

--- a/ellipse-core/src/main/java/com/tomcz/ellipse/common/ViewModelExtension.kt
+++ b/ellipse-core/src/main/java/com/tomcz/ellipse/common/ViewModelExtension.kt
@@ -2,24 +2,24 @@ package com.tomcz.ellipse.common
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.tomcz.ellipse.PartialState
 import com.tomcz.ellipse.Processor
+import com.tomcz.ellipse.PartialState
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.emptyFlow
 
-fun <EV : Any, EF : Any> ViewModel.processor(
-    prepare: suspend EllipseContext<Unit, EF>.() -> Unit = {},
-    onEvent: suspend EllipseContext<Unit, EF>.(EV) -> Unit = {},
+inline fun <EV : Any, reified EF : Any> ViewModel.processor(
+    noinline prepare: suspend EllipseContext<Unit, EF>.() -> Unit = {},
+    noinline onEvent: suspend EllipseContext<Unit, EF>.(EV) -> Unit = {},
 ): Processor<EV, Unit, EF> = viewModelScope.processor(
     initialState = Unit,
     prepare = { prepare(); emptyFlow() },
     onEvent = { onEvent(it); emptyFlow() }
 )
 
-fun <EV : Any, ST : Any, PA : PartialState<ST>, EF : Any> ViewModel.processor(
+inline fun <EV : Any, ST : Any, PA : PartialState<ST>, reified EF : Any> ViewModel.processor(
     initialState: ST,
-    prepare: suspend EllipseContext<ST, EF>.() -> Flow<PA> = { emptyFlow() },
-    onEvent: suspend EllipseContext<ST, EF>.(EV) -> Flow<PA> = { emptyFlow() },
+    noinline prepare: suspend EllipseContext<ST, EF>.() -> Flow<PA> = { emptyFlow() },
+    noinline onEvent: suspend EllipseContext<ST, EF>.(EV) -> Flow<PA> = { emptyFlow() },
 ): Processor<EV, ST, EF> = viewModelScope.processor(
     initialState = initialState,
     prepare = prepare,

--- a/ellipse-core/src/main/java/com/tomcz/ellipse/common/ViewModelExtension.kt
+++ b/ellipse-core/src/main/java/com/tomcz/ellipse/common/ViewModelExtension.kt
@@ -2,8 +2,8 @@ package com.tomcz.ellipse.common
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.tomcz.ellipse.Processor
 import com.tomcz.ellipse.PartialState
+import com.tomcz.ellipse.Processor
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.emptyFlow
 

--- a/ellipse-core/src/main/java/com/tomcz/ellipse/internal/FlowProcessor.kt
+++ b/ellipse-core/src/main/java/com/tomcz/ellipse/internal/FlowProcessor.kt
@@ -6,28 +6,41 @@ import com.tomcz.ellipse.Processor
 import com.tomcz.ellipse.common.EllipseContext
 import com.tomcz.ellipse.internal.util.reduceAndSet
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.flatMapConcat
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.isActive
+import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import kotlin.reflect.KClass
+import kotlin.reflect.full.isSubclassOf
 
-internal class FlowProcessor<in EV : Any, ST : Any, out PA : PartialState<ST>, EF : Any> constructor(
+class FlowProcessor<in EV : Any, ST : Any, out PA : PartialState<ST>, EF : Any> constructor(
     private val scope: CoroutineScope,
+    private val effectClass: KClass<EF>,
     initialState: ST,
     prepare: suspend EllipseContext<ST, EF>.() -> Flow<PA>,
     private val onEvent: suspend EllipseContext<ST, EF>.(EV) -> Flow<PA>,
 ) : Processor<EV, ST, EF> {
 
     override val effect: Flow<EF>
-        get() = effectSharedFlow
-    private val effectSharedFlow: MutableSharedFlow<EF> = MutableSharedFlow(replay = 0)
+        get() = effect(effectClass)
+
+    private val effectFlows: MutableMap<KClass<out EF>, MutableSharedFlow<Any>> = mutableMapOf()
 
     override val state: StateFlow<ST>
         get() = stateFlow
     private val stateFlow: MutableStateFlow<ST> = MutableStateFlow(initialState)
 
-    private val effectCache: MutableList<EF> = mutableListOf()
+    private val effectCache: MutableMap<KClass<out EF>, MutableList<Any>> = mutableMapOf()
 
     private val context: EllipseContext<ST, EF>
         get() = EllipseContext(state, effectsCollector)
@@ -35,12 +48,10 @@ internal class FlowProcessor<in EV : Any, ST : Any, out PA : PartialState<ST>, E
     private val effectsCollector: EffectsCollector<EF> = object : EffectsCollector<EF> {
         override fun send(vararg effect: EF) {
             scope.launch {
-                effect.forEach {
-                    if (effectSharedFlow.subscriptionCount.value != 0) {
-                        effectSharedFlow.emit(it)
-                    } else {
-                        effectCache.add(it)
-                    }
+                effect.forEach { effect ->
+                    effectFlows.keys
+                        .filter { key -> effect::class.isSubclassOf(key) }
+                        .onEach { key -> emitEffect(key, effect) }
                 }
             }
         }
@@ -48,23 +59,65 @@ internal class FlowProcessor<in EV : Any, ST : Any, out PA : PartialState<ST>, E
 
     init {
         scope.launch {
-            effectSharedFlow.subscriptionCount.collect { subscribers ->
-                if (subscribers != 0) {
-                    while (effectCache.isNotEmpty()) {
-                        effectSharedFlow.emit(effectCache.removeFirst())
-                    }
-                }
-            }
-        }
-        scope.launch {
             prepare(context).collect { stateFlow.reduceAndSet(it) }
         }
     }
+
+    @OptIn(FlowPreview::class)
+    override fun <T : EF> effect(filterClass: KClass<T>): Flow<T> = flow {
+        emit(setupEffectFlow(filterClass))
+    }.flatMapConcat { it }
 
     override fun sendEvent(vararg event: EV) {
         scope.launch {
             event.forEach {
                 onEvent(context, it).collect { partial -> stateFlow.reduceAndSet(partial) }
+            }
+        }
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private suspend fun <T : EF> setupEffectFlow(
+        filterClass: KClass<T>
+    ): Flow<T> = withContext(scope.coroutineContext) {
+        if (effectFlows.contains(filterClass)) {
+            effectFlows[filterClass] as Flow<T>
+        } else {
+            val sharedFlow = MutableSharedFlow<Any>()
+            effectFlows[filterClass] = sharedFlow
+            sharedFlow.addCacheObserver(filterClass)
+            sharedFlow as Flow<T>
+        }
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    private fun <T : EF> MutableSharedFlow<Any>.addCacheObserver(filterClass: KClass<T>) {
+        subscriptionCount
+            .flatMapLatest { subscribers ->
+                if (subscribers != 0) {
+                    while (effectCache[filterClass]?.isNotEmpty() == true) {
+                        effectCache[filterClass]
+                            ?.removeFirst()
+                            ?.let { cachedEffect -> this@addCacheObserver.emit(cachedEffect) }
+                    }
+                }
+                flowOf(Unit)
+            }
+            .launchIn(scope)
+    }
+
+    private suspend fun emitEffect(key: KClass<out EF>, effect: EF) {
+        val flow = effectFlows[key]
+        if (flow != null && flow.subscriptionCount.value != 0) {
+            flow.emit(effect)
+        } else {
+            val cache = effectCache[key]
+            if (cache != null) {
+                cache.add(effect)
+            } else {
+                effectCache[key] = mutableListOf<Any>().also {
+                    it.add(effect)
+                }
             }
         }
     }

--- a/ellipse-core/src/main/java/com/tomcz/ellipse/internal/FlowProcessor.kt
+++ b/ellipse-core/src/main/java/com/tomcz/ellipse/internal/FlowProcessor.kt
@@ -114,9 +114,7 @@ class FlowProcessor<in EV : Any, ST : Any, out PA : PartialState<ST>, EF : Any> 
             if (cache != null) {
                 cache.add(effect)
             } else {
-                effectCache[key] = mutableListOf<Any>().also {
-                    it.add(effect)
-                }
+                effectCache[key] = mutableListOf(effect)
             }
         }
     }

--- a/ellipse-core/src/main/java/com/tomcz/ellipse/internal/FlowProcessor.kt
+++ b/ellipse-core/src/main/java/com/tomcz/ellipse/internal/FlowProcessor.kt
@@ -16,7 +16,6 @@ import kotlinx.coroutines.flow.flatMapConcat
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
-import kotlinx.coroutines.flow.isActive
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext

--- a/ellipse-core/src/test/java/com/tomcz/ellipse/internal/CounterState.kt
+++ b/ellipse-core/src/test/java/com/tomcz/ellipse/internal/CounterState.kt
@@ -2,9 +2,15 @@ package com.tomcz.ellipse.internal
 
 import com.tomcz.ellipse.PartialState
 
-object CounterEvent
+sealed interface CounterEvent {
+    object Event1 : CounterEvent
+    object Event2 : CounterEvent
+}
 
-object CounterEffect
+sealed interface CounterEffect {
+    object Effect1 : CounterEffect
+    object Effect2 : CounterEffect
+}
 
 data class CounterState(val counter: Int = 0)
 

--- a/ellipse-core/src/test/java/com/tomcz/ellipse/internal/FlowEffectProcessorTest.kt
+++ b/ellipse-core/src/test/java/com/tomcz/ellipse/internal/FlowEffectProcessorTest.kt
@@ -22,12 +22,12 @@ internal class FlowEffectProcessorTest : BaseCoroutineTest() {
     fun `test effect`() = runTest {
         val processorScope = TestScope(testScheduler)
         val processor: CounterEffectProcessor =
-            processorScope.processor { effects.send(CounterEffect) }
+            processorScope.processor { effects.send(CounterEffect.Effect1) }
         val effects = mutableListOf<CounterEffect>()
         val effectJob = launch { processor.effect.collect { effects.add(it) } }
-        processor.sendEvent(CounterEvent)
+        processor.sendEvent(CounterEvent.Event1)
         runCurrent()
-        assertEquals(listOf(CounterEffect), effects)
+        assertEquals(listOf(CounterEffect.Effect1), effects)
         effectJob.cancelAndJoin()
         processorScope.cancel()
     }
@@ -36,12 +36,12 @@ internal class FlowEffectProcessorTest : BaseCoroutineTest() {
     fun `test resubscribing effects`() = runTest {
         val processorScope = TestScope(testScheduler)
         val processor: CounterEffectProcessor =
-            processorScope.processor { effects.send(CounterEffect) }
+            processorScope.processor { effects.send(CounterEffect.Effect1) }
         val effects = mutableListOf<CounterEffect>()
         val effectJob = launch { processor.effect.collect { effects.add(it) } }
-        processor.sendEvent(CounterEvent)
+        processor.sendEvent(CounterEvent.Event1)
         runCurrent()
-        assertEquals(listOf(CounterEffect), effects)
+        assertEquals(listOf(CounterEffect.Effect1), effects)
         effectJob.cancelAndJoin()
 
         // Test resubscribing
@@ -56,13 +56,14 @@ internal class FlowEffectProcessorTest : BaseCoroutineTest() {
     fun `test having multiple subscribers`() = runTest {
         val processorScope = TestScope(testScheduler)
         val processor: CounterEffectProcessor =
-            processorScope.processor { effects.send(CounterEffect) }
+            processorScope.processor { effects.send(CounterEffect.Effect1) }
         val effects = mutableListOf<CounterEffect>()
         val effectJob = launch { processor.effect.collect { effects.add(it) } }
         val effect2Job = launch { processor.effect.collect { effects.add(it) } }
-        processor.sendEvent(CounterEvent)
         runCurrent()
-        assertEquals(listOf(CounterEffect, CounterEffect), effects)
+        processor.sendEvent(CounterEvent.Event1)
+        runCurrent()
+        assertEquals(listOf(CounterEffect.Effect1, CounterEffect.Effect1), effects)
         effectJob.cancelAndJoin()
         effect2Job.cancelAndJoin()
 
@@ -78,23 +79,23 @@ internal class FlowEffectProcessorTest : BaseCoroutineTest() {
     fun `test caching effects when there are no subscribers`() = runTest {
         val processorScope = TestScope(testScheduler)
         val processor: CounterEffectProcessor = processorScope.processor {
-            effects.send(CounterEffect)
+            effects.send(CounterEffect.Effect1)
         }
         val effects = mutableListOf<CounterEffect>()
         val effectJob = launch { processor.effect.collect { effects.add(it) } }
-        processor.sendEvent(CounterEvent)
+        processor.sendEvent(CounterEvent.Event1)
         runCurrent()
-        assertEquals(listOf(CounterEffect), effects)
+        assertEquals(listOf(CounterEffect.Effect1), effects)
         effectJob.cancelAndJoin()
 
-        processor.sendEvent(CounterEvent)
-        processor.sendEvent(CounterEvent)
+        processor.sendEvent(CounterEvent.Event1)
+        processor.sendEvent(CounterEvent.Event1)
 
         // Test resubscribing
         val cachedEffects = mutableListOf<CounterEffect>()
         val cachedEffectsJob = launch { processor.effect.collect { cachedEffects.add(it) } }
         runCurrent()
-        assertEquals(listOf(CounterEffect, CounterEffect), cachedEffects)
+        assertEquals(listOf(CounterEffect.Effect1, CounterEffect.Effect1), cachedEffects)
         cachedEffectsJob.cancelAndJoin()
         processorScope.cancel()
     }

--- a/sample/src/main/java/com/tomcz/sample/feature/register/RegisterFragment.kt
+++ b/sample/src/main/java/com/tomcz/sample/feature/register/RegisterFragment.kt
@@ -46,6 +46,8 @@ import com.tomcz.ellipse.common.collectAsState
 import com.tomcz.ellipse.common.onProcessor
 import com.tomcz.sample.R
 import com.tomcz.sample.feature.register.state.RegisterEffect
+import com.tomcz.sample.feature.register.state.RegisterEffect.GoToHome
+import com.tomcz.sample.feature.register.state.RegisterEffect.GoToLogin
 import com.tomcz.sample.feature.register.state.RegisterEvent
 import com.tomcz.sample.ui.BasePadding
 import com.tomcz.sample.ui.BezierBackground
@@ -86,11 +88,11 @@ class RegisterFragment : Fragment() {
 
     private fun trigger(effect: RegisterEffect) {
         when (effect) {
-            RegisterEffect.GoToLogin ->
+            GoToLogin ->
                 findNavController().navigate(
                     RegisterFragmentDirections.actionRegisterFragmentToLoginFragment()
                 )
-            RegisterEffect.GoToHome -> TODO()
+            GoToHome -> TODO()
         }
     }
 }


### PR DESCRIPTION
Previously, effects supported only a single subscriber; otherwise the cache wouldn't work properly. Imagine a scenario where you're using effect for navigation. If that effect is emitted when the application is in the background, it'll be cached, and replayed after foregrounding, thanks to this we're not losing events in the background. But such cache by default doesn't play well with Compose where we might be using multiple subscribers. Cache is emitted for the first subscriber only. 

In this PR we can subscribe to effects using particular class as a filter. This creates new separate cache for this class only.
Example code:

```kotlin
sealed interface MyEffect {
  object Effect1 : MyEffect
  object Effect2 : MyEffect
}

// In compose, collect effect scoped for single subclass, which uses separate cache
processor.collectEffect(Effect1::class) { /* it is Effect1 */ }
```